### PR TITLE
fix(skeleton-bbox): rotation, undo atomicity, interpolation & bbox containment

### DIFF
--- a/changelog.d/20260519_000000_liam_skeleton_bbox.md
+++ b/changelog.d/20260519_000000_liam_skeleton_bbox.md
@@ -51,6 +51,18 @@
 
 ### Fixed
 
+- skeleton 편집(전체 이동/리사이즈/keypoint 이동) 1회가 히스토리 엔트리
+  2~3개로 쪼개져 undo를 여러 번 눌러야 하고, 중간 단계에서 bbox만 따로
+  복원되어 객체에서 벗어나 보이던 문제 수정. keypoint와 bbox 변경이 단일
+  히스토리 엔트리로 통합되어 undo/redo 1회로 함께 복원됨. element 편집은
+  부모 skeleton 1회 저장으로 합쳐져(이중 저장 제거) keypoint 이동 시
+  soft-snap bbox 확장도 정상 동작.
+- skeleton element 일괄 갱신(updateElements)이 부분집합을 위치 인덱스로
+  매칭해 잘못된 element를 갱신할 수 있던 잠재 버그 수정 (clientID 매칭).
+- label의 skeleton SVG 구조와 sublabel이 불일치할 때(`data-label-id` 누락
+  등) 캔버스 전체가 TypeError로 죽던 문제 수정 — 해당 keypoint만 건너뛰고
+  콘솔 경고를 남김.
+
 - skeleton rotation이 마우스를 놓는 순간 사라지던 문제 수정: 회전이 어떤
   영속 상태에도 반영되지 않았음. 이제 마우스업 시 cvat-core가 회전을
   keypoint 좌표에 베이크하고 필요 시 bbox를 확장. 제스처 중 wrapping

--- a/changelog.d/20260519_000000_liam_skeleton_bbox.md
+++ b/changelog.d/20260519_000000_liam_skeleton_bbox.md
@@ -51,6 +51,20 @@
 
 ### Fixed
 
+- skeleton을 다른 객체와 다중선택해 드래그(multi-drag)하면 wrapping bbox가
+  따라 이동하지 않고 옛 위치+새 위치를 모두 포함해 비대해지던 문제 수정.
+  `canvas.multiedited` payload에 skeleton bbox를 포함하고 `onCanvasMultiEdited`
+  가 이를 적용해, 멀티드래그 시에도 bbox가 keypoint와 함께 평행이동.
+- skeleton track export 시 parent keyframe의 (구버전 데이터에서 유래한) 0이
+  아닌 rotation이 그대로 서버로 round-trip되던 문제 수정 (`toJSON`이 parent
+  rotation을 항상 0으로). skeleton 회전은 child keypoint에 baked.
+- skeleton keypoint가 SVG 템플릿에 없어 렌더에서 스킵될 때, 이후 드래그
+  저장이 point 개수 불일치로 크래시하던 잠재 버그 수정 (스킵된 keypoint는
+  마지막 좌표로 채워 개수 정합 유지).
+- skeleton bbox/points에 비유한(NaN/Infinity) 좌표가 들어오면 NaN bbox로
+  표시/export되던 방어 공백 수정 (`ObjectState` setter 및 보간/export의
+  finite 검사 강화).
+
 - skeleton track 보간에서 keyframe의 bbox가 degenerate `[0,0,0,0]`(미영속)
   이면, 그 0값을 그대로 선형보간해 이미지 원점에서 자라나는 작은 박스가
   keypoint를 벗어나던 문제 수정. 예: 첫 keyframe은 bbox 미설정 상태로 두고

--- a/changelog.d/20260519_000000_liam_skeleton_bbox.md
+++ b/changelog.d/20260519_000000_liam_skeleton_bbox.md
@@ -57,6 +57,15 @@
   뒤쪽 keyframe에서만 bbox를 그리면 그 사이 프레임 전체의 박스가 좌상단으로
   어긋남. 이제 `getPosition`이 보간 전에 degenerate bbox를 해당 keyframe의
   keypoint extent(+margin)로 해석해, 모든 프레임에서 박스가 keypoint를 감쌈.
+- skeleton track에서 keypoint가 bbox 밖으로 나가도 박스가 따라가지 않던
+  문제 수정. single-keyframe keypoint는 전 프레임에 공유되는데 parent bbox
+  keyframe은 독립적이라, 한 프레임에서 그 keypoint를 옮기면 그 프레임의
+  bbox만 soft-snap되고 다른 keyframe(및 그로부터 보간된 모든 프레임)의
+  bbox는 stale하게 남아 keypoint가 박스 밖으로 삐져나옴. 어떤 단일 편집
+  훅으로도 모든 keyframe을 일관되게 유지할 수 없으므로, bbox가 도출되는
+  단일 지점인 `getPosition`에서 표시 bbox가 항상 그 프레임의 visible
+  keypoint를 감싸도록(확장-only) 보장. export(`toJSON`)도 각 keyframe의
+  bbox를 그 keypoint를 감싸도록 확장해 재import 후 보간 정합성 유지.
 - skeleton 편집(전체 이동/리사이즈/keypoint 이동) 1회가 히스토리 엔트리
   2~3개로 쪼개져 undo를 여러 번 눌러야 하고, 중간 단계에서 bbox만 따로
   복원되어 객체에서 벗어나 보이던 문제 수정. keypoint와 bbox 변경이 단일

--- a/changelog.d/20260519_000000_liam_skeleton_bbox.md
+++ b/changelog.d/20260519_000000_liam_skeleton_bbox.md
@@ -51,6 +51,12 @@
 
 ### Fixed
 
+- skeleton track 보간에서 keyframe의 bbox가 degenerate `[0,0,0,0]`(미영속)
+  이면, 그 0값을 그대로 선형보간해 이미지 원점에서 자라나는 작은 박스가
+  keypoint를 벗어나던 문제 수정. 예: 첫 keyframe은 bbox 미설정 상태로 두고
+  뒤쪽 keyframe에서만 bbox를 그리면 그 사이 프레임 전체의 박스가 좌상단으로
+  어긋남. 이제 `getPosition`이 보간 전에 degenerate bbox를 해당 keyframe의
+  keypoint extent(+margin)로 해석해, 모든 프레임에서 박스가 keypoint를 감쌈.
 - skeleton 편집(전체 이동/리사이즈/keypoint 이동) 1회가 히스토리 엔트리
   2~3개로 쪼개져 undo를 여러 번 눌러야 하고, 중간 단계에서 bbox만 따로
   복원되어 객체에서 벗어나 보이던 문제 수정. keypoint와 bbox 변경이 단일

--- a/changelog.d/20260519_000000_liam_skeleton_bbox.md
+++ b/changelog.d/20260519_000000_liam_skeleton_bbox.md
@@ -26,11 +26,12 @@
     bbox를 안 보낸 write 요청. 캔버스/export가 keypoint extent로 폴백하고, 첫
     편집 시 soft-snap으로 영속화)
   - 그 외 입력 (zero-area non-degenerate, 역전된 좌표, len≠4)은 모두 400.
-- skeleton 회전 의미 변경: 기존엔 `Shape.rotation`을 항상 0으로 강제하고
-  child keypoint 좌표를 직접 회전시켰음. 이제 `Shape.rotation`이 의미 있는
-  스칼라로 보존되고, child keypoint는 변형되지 않으며, 캔버스가 SVG
-  transform으로 시각적 회전을 처리. 데이터셋 export (CVAT XML, COCO,
-  Datumaro)도 skeleton rotation을 보존.
+- skeleton 회전: 회전은 child keypoint 좌표에 즉시 베이크되고
+  (`Shape.rotation`은 skeleton에서 항상 0), **bbox는 회전하지 않고 항상
+  axis-aligned 직사각형을 유지**. 회전 피벗은 저장된 bbox 중심(없으면
+  keypoint extent 중심). 회전된 keypoint가 기존 bbox를 벗어나면 bbox가
+  자동 확장되며(soft-snap), 절대 회전/축소되지 않음. 회전 제스처 중에는
+  keypoint와 edge만 시각적으로 회전하고 wrapping rect는 upright 유지.
 - skeleton 빨간 박스 corner/edge 핸들 드래그가 **bbox만** 변경하도록 의미
   재정의. 이전엔 모든 keypoint를 박스 변화에 비례해 스케일했음. line 드래그
   (테두리 잡기)는 기존 동작 유지 — bbox + keypoints가 함께 평행이동.
@@ -50,6 +51,14 @@
 
 ### Fixed
 
+- skeleton rotation이 마우스를 놓는 순간 사라지던 문제 수정: 회전이 어떤
+  영속 상태에도 반영되지 않았음. 이제 마우스업 시 cvat-core가 회전을
+  keypoint 좌표에 베이크하고 필요 시 bbox를 확장. 제스처 중 wrapping
+  rect가 마름모꼴로 기울던 표시도 제거(항상 upright).
+- skeleton track의 per-frame bbox가 implicit keyframe 생성(`copyShape`)과
+  서버 reload(`convertTrackedShape`) 경로에서 유실되던 문제 수정. 보간
+  frame에서 회전/편집해도 keyframe bbox가 보존되고, 새로고침 후에도 저장된
+  bbox가 유지됨.
 - Datumaro IR을 통한 skeleton transport에서 reserved-prefix attribute
   `__cvat_bbox` 사용. `quality_control` 의 `ignored_attrs` 와
   `consensus` merge 경로에서 이 attribute를 자동 제외해 transport metadata

--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -1260,17 +1260,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
         }
 
         if (objState.shapeType === 'skeleton') {
-            const points: number[] = [];
-            objState.elements.forEach((element: any) => {
-                const elementShape = (svgShape as SVG.G).children()
-                    .find((child: SVG.Shape) => (
-                        child.id() === `cvat_canvas_shape_${element.clientID}`
-                    ));
-                if (elementShape) {
-                    points.push(...this.translateFromCanvas(readPointsFromShape(elementShape)));
-                }
-            });
-            return points;
+            return this.collectSkeletonPoints(objState, svgShape as SVG.G);
         }
 
         let points = readPointsFromShape(svgShape);
@@ -1279,6 +1269,38 @@ export class CanvasViewImpl implements CanvasView, Listener {
             points = this.translatePointsFromRotatedShape(svgShape, points);
         }
         return this.translateFromCanvas(points);
+    }
+
+    // Collect a skeleton's keypoint coordinates (image space) in element
+    // order. When a keypoint has no rendered circle — its sublabel is missing
+    // from the SVG template, so addSkeleton skipped it — fall back to the
+    // element's last-known coords so the array length always matches
+    // state.elements (ObjectState.points rejects a length mismatch).
+    private collectSkeletonPoints(objState: any, svgGroup: SVG.G): number[] {
+        const points: number[] = [];
+        objState.elements.forEach((element: any) => {
+            const elementShape = svgGroup.children()
+                .find((child: SVG.Shape) => child.id() === `cvat_canvas_shape_${element.clientID}`);
+            if (elementShape) {
+                points.push(...this.translateFromCanvas(readPointsFromShape(elementShape)));
+            } else {
+                points.push(...element.points);
+            }
+        });
+        return points;
+    }
+
+    // Read a skeleton's wrapping rect and return its bbox in image space.
+    private collectSkeletonBbox(svgGroup: SVG.G): number[] | undefined {
+        const wrapRect = svgGroup.children().find((child: SVG.Element) => child.type === 'rect');
+        if (!wrapRect) return undefined;
+        const xtl = +wrapRect.attr('data-xtl');
+        const ytl = +wrapRect.attr('data-ytl');
+        const xbr = +wrapRect.attr('data-xbr');
+        const ybr = +wrapRect.attr('data-ybr');
+        const origin = this.translateFromCanvas([xtl, ytl]);
+        const far = this.translateFromCanvas([xbr, ybr]);
+        return [origin[0], origin[1], far[0], far[1]];
     }
 
     private draggable(
@@ -1388,25 +1410,34 @@ export class CanvasViewImpl implements CanvasView, Listener {
                 const hasMoved = Math.sqrt(dx2 + dy2) > 0;
 
                 if (hasMoved && selectedStartData.size > 0) {
-                    // Multi-drag completion: collect points for all moved shapes
-                    const edits: { state: any; points: number[] }[] = [];
+                    // Multi-drag completion: collect points for all moved shapes.
+                    // For skeletons the wrapping bbox translated with the
+                    // keypoints, so carry it too — otherwise cvat-core seeds the
+                    // soft-snap from the OLD bbox and expands it to span both the
+                    // old and new locations instead of translating it.
+                    const edits: { state: any; points: number[]; bbox?: number[] }[] = [];
+                    const collectEdit = (editState: any, editShape: SVG.Shape): typeof edits[0] => {
+                        const edit: typeof edits[0] = {
+                            state: editState,
+                            points: this.collectShapePoints(editState, editShape),
+                        };
+                        if (editState.shapeType === 'skeleton') {
+                            const bbox = this.collectSkeletonBbox(editShape as SVG.G);
+                            if (bbox) edit.bbox = bbox;
+                        }
+                        return edit;
+                    };
 
-                    // Primary shape points
-                    edits.push({
-                        state,
-                        points: this.collectShapePoints(state, shape),
-                    });
+                    // Primary shape
+                    edits.push(collectEdit(state, shape));
 
-                    // Selected shapes points
+                    // Selected shapes
                     const { objects } = this.controller;
                     for (const [id] of selectedStartData) {
                         const selectedShape = this.svgShapes[id];
                         const selectedObjState = objects.find((obj: any) => obj.clientID === id);
                         if (selectedShape && selectedObjState) {
-                            edits.push({
-                                state: selectedObjState,
-                                points: this.collectShapePoints(selectedObjState, selectedShape),
-                            });
+                            edits.push(collectEdit(selectedObjState, selectedShape));
                         }
                     }
 
@@ -1454,35 +1485,11 @@ export class CanvasViewImpl implements CanvasView, Listener {
                         points.push(x, y, x + shape.width() - 1, y + shape.height() - 1);
                         this.onEditDone(state, points);
                     } else if (state.shapeType === 'skeleton') {
-                        const points = [];
-                        state.elements.forEach((element: any) => {
-                            const elementShape = (shape as SVG.G).children()
-                                .find((child: SVG.Shape) => (
-                                    child.id() === `cvat_canvas_shape_${element.clientID}`
-                                ));
-
-                            if (elementShape) {
-                                points.push(...this.translateFromCanvas(readPointsFromShape(elementShape)));
-                            }
-                        });
                         // line drag = whole-skeleton translation: emit the bbox
                         // that just got translated alongside the new keypoint
                         // coordinates so cvat-core persists both consistently.
-                        const wrapRect = (shape as any).children()
-                            .find((child: SVG.Element) => child.type === 'rect');
-                        let movedBbox: number[] | undefined;
-                        if (wrapRect) {
-                            const xtl = +wrapRect.attr('data-xtl');
-                            const ytl = +wrapRect.attr('data-ytl');
-                            const xbr = +wrapRect.attr('data-xbr');
-                            const ybr = +wrapRect.attr('data-ybr');
-                            const canvasOrigin = this.translateFromCanvas([xtl, ytl]);
-                            const canvasFar = this.translateFromCanvas([xbr, ybr]);
-                            movedBbox = [
-                                canvasOrigin[0], canvasOrigin[1],
-                                canvasFar[0], canvasFar[1],
-                            ];
-                        }
+                        const points = this.collectSkeletonPoints(state, shape as SVG.G);
+                        const movedBbox = this.collectSkeletonBbox(shape as SVG.G);
                         this.onEditDone(state, points, undefined, movedBbox);
                     } else {
                         // these points does not take into account possible transformations, applied on the element
@@ -1760,37 +1767,9 @@ export class CanvasViewImpl implements CanvasView, Listener {
                             // unrotated coordinates, and any consumer writing
                             // them back would revert the rotation it just
                             // requested.
-                            const points: number[] = [];
-                            if (!rotation) {
-                                state.elements.forEach((element: any) => {
-                                    const elementShape = (shape as SVG.G).children()
-                                        .find((child: SVG.Shape) => (
-                                            child.id() === `cvat_canvas_shape_${element.clientID}`
-                                        ));
-
-                                    if (elementShape) {
-                                        points.push(...this.translateFromCanvas(
-                                            readPointsFromShape(elementShape),
-                                        ));
-                                    }
-                                });
-                            }
-
-                            const wrapRect = (shape as any).children()
-                                .find((child: SVG.Element) => child.type === 'rect');
-                            let resizedBbox: number[] | undefined;
-                            if (wrapRect) {
-                                const xtl = +wrapRect.attr('data-xtl');
-                                const ytl = +wrapRect.attr('data-ytl');
-                                const xbr = +wrapRect.attr('data-xbr');
-                                const ybr = +wrapRect.attr('data-ybr');
-                                const canvasOrigin = this.translateFromCanvas([xtl, ytl]);
-                                const canvasFar = this.translateFromCanvas([xbr, ybr]);
-                                resizedBbox = [
-                                    canvasOrigin[0], canvasOrigin[1],
-                                    canvasFar[0], canvasFar[1],
-                                ];
-                            }
+                            const points: number[] = rotation ?
+                                [] : this.collectSkeletonPoints(state, shape as SVG.G);
+                            const resizedBbox = this.collectSkeletonBbox(shape as SVG.G);
                             this.onEditDone(state, points, rotation, resizedBbox);
                         } else {
                             // these points does not take into account possible transformations, applied on the element

--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -3941,6 +3941,17 @@ export class CanvasViewImpl implements CanvasView, Listener {
                 }
 
                 const templateElement = templateElements.find((el: SVG.Circle) => el.attr('data-label-id') === element.label.id);
+                if (!templateElement) {
+                    // a label whose SVG template does not reference this
+                    // sublabel (e.g. created/edited via raw API) must not
+                    // crash the whole canvas — skip the keypoint instead
+                    // eslint-disable-next-line no-console
+                    console.warn(
+                        `Skeleton sublabel #${element.label.id} (${element.label.name}) ` +
+                        'is missing in the skeleton SVG template, its keypoint was skipped',
+                    );
+                    continue;
+                }
                 const circle = skeleton.circle()
                     .center(cx, cy)
                     .attr({

--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -1605,6 +1605,13 @@ export class CanvasViewImpl implements CanvasView, Listener {
             // cvat-core bakes the angle into keypoint coordinates.
             let skeletonGestureRotation = 0;
 
+            // make attaching idempotent — re-activation must never stack a
+            // second set of handlers on the same element
+            (resizableInstance as any).off('resizestart');
+            (resizableInstance as any).off('resizing');
+            (resizableInstance as any).off('resizedone');
+            (resizableInstance as any).off('resizeabort');
+
             (resizableInstance as any)
                 .resize({
                     snapToGrid: 0.1,
@@ -1748,20 +1755,26 @@ export class CanvasViewImpl implements CanvasView, Listener {
                             // angle is emitted and baked into keypoints in
                             // cvat-core; the bbox stays axis-aligned (it only
                             // auto-expands there if rotated keypoints exceed
-                            // it). Element points are passed through unchanged.
+                            // it). A rotation gesture must emit EMPTY points:
+                            // the canvas-side circle attributes are the
+                            // unrotated coordinates, and any consumer writing
+                            // them back would revert the rotation it just
+                            // requested.
                             const points: number[] = [];
-                            state.elements.forEach((element: any) => {
-                                const elementShape = (shape as SVG.G).children()
-                                    .find((child: SVG.Shape) => (
-                                        child.id() === `cvat_canvas_shape_${element.clientID}`
-                                    ));
+                            if (!rotation) {
+                                state.elements.forEach((element: any) => {
+                                    const elementShape = (shape as SVG.G).children()
+                                        .find((child: SVG.Shape) => (
+                                            child.id() === `cvat_canvas_shape_${element.clientID}`
+                                        ));
 
-                                if (elementShape) {
-                                    points.push(...this.translateFromCanvas(
-                                        readPointsFromShape(elementShape),
-                                    ));
-                                }
-                            });
+                                    if (elementShape) {
+                                        points.push(...this.translateFromCanvas(
+                                            readPointsFromShape(elementShape),
+                                        ));
+                                    }
+                                });
+                            }
 
                             const wrapRect = (shape as any).children()
                                 .find((child: SVG.Element) => child.type === 'rect');
@@ -1813,11 +1826,17 @@ export class CanvasViewImpl implements CanvasView, Listener {
                 resizableInstance.fire('resizeabort');
             }
 
-            (shape as any).off('resizestart');
-            (shape as any).off('resizing');
-            (shape as any).off('resizedone');
-            (shape as any).off('resizeabort');
-            (shape as any).resize('stop');
+            // detach from resizableInstance, not shape: for skeletons the
+            // resize events live on the wrapping rect (a child of the group).
+            // Detaching from the group left the rect listeners in place, so
+            // every activate/deactivate cycle stacked one more set of
+            // handlers — a single mouseup then fired resizedone N times,
+            // and the duplicate events corrupted the annotation
+            (resizableInstance as any).off('resizestart');
+            (resizableInstance as any).off('resizing');
+            (resizableInstance as any).off('resizedone');
+            (resizableInstance as any).off('resizeabort');
+            (resizableInstance as any).resize('stop');
         }
     }
 

--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -282,6 +282,11 @@ export class CanvasViewImpl implements CanvasView, Listener {
             } else if (shapeType === 'skeleton') {
                 drawnShape.rotate(0);
                 for (const child of (drawnShape as SVG.G).children()) {
+                    if (child.type === 'circle' || child.type === 'line') {
+                        // drop transient rotation transforms left by an
+                        // aborted rotation gesture
+                        child.untransform();
+                    }
                     if (child.type === 'circle') {
                         const childClientID = child.attr('data-client-id');
                         const element = drawnState.elements.find((el: any) => el.clientID === childClientID);
@@ -1591,6 +1596,14 @@ export class CanvasViewImpl implements CanvasView, Listener {
             let resized = false;
             let aborted = false;
             let start = Date.now();
+            // Final angle of an ongoing skeleton rotation gesture. Skeleton
+            // rotation is visualized with transient transforms on keypoint
+            // circles and edge lines only — the group and the wrapping rect
+            // are never rotated (the bbox stays an axis-aligned rectangle by
+            // definition), so the angle cannot be read back from the group
+            // transform on resizedone and must be tracked here. On mouseup
+            // cvat-core bakes the angle into keypoint coordinates.
+            let skeletonGestureRotation = 0;
 
             (resizableInstance as any)
                 .resize({
@@ -1601,6 +1614,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
                     onResizeStart();
                     resized = false;
                     start = Date.now();
+                    skeletonGestureRotation = 0;
                     this.resizableShape = shape;
                 })
                 .on('resizing', (e: CustomEvent): void => {
@@ -1610,10 +1624,16 @@ export class CanvasViewImpl implements CanvasView, Listener {
                     if (state.shapeType === 'skeleton' && e.target) {
                         const { instance } = e.target as any;
 
-                        // Rotation handle still drives the parent skeleton's
-                        // SVG rotation; the bbox stays axis-aligned.
+                        // svg.resize rotates the wrapping rect itself on
+                        // rotation-handle drag. Undo that — the bbox stays an
+                        // axis-aligned rectangle; keypoints and edges get a
+                        // transient visual rotation around the bbox center
+                        // below instead.
                         const { rotation } = resizableInstance.transform();
-                        shape.rotate(rotation);
+                        skeletonGestureRotation = rotation;
+                        if (rotation) {
+                            resizableInstance.rotate(0);
+                        }
 
                         let [x, y] = [instance.x(), instance.y()];
                         let width = instance.width();
@@ -1682,6 +1702,24 @@ export class CanvasViewImpl implements CanvasView, Listener {
                         resized = true;
                         skeletonSVGTemplate = skeletonSVGTemplate ?? makeSVGFromTemplate(state.label.structure.svg);
                         setupSkeletonEdges(shape as SVG.G, skeletonSVGTemplate);
+
+                        // Transient visual rotation of keypoints and skeleton
+                        // edges around the bbox center while the rotation
+                        // handle is being dragged. The wrapping rect stays
+                        // upright. The transforms disappear with the full
+                        // redraw after mouseup, when the angle has been baked
+                        // into the keypoint coordinates by cvat-core.
+                        const pivotX = x + width / 2;
+                        const pivotY = y + height / 2;
+                        for (const child of (shape as SVG.G).children()) {
+                            if (child.type === 'circle' || child.type === 'line') {
+                                if (skeletonGestureRotation) {
+                                    child.rotate(skeletonGestureRotation, pivotX, pivotY);
+                                } else {
+                                    child.untransform();
+                                }
+                            }
+                        }
                     }
                 })
                 .on('resizedone', (): void => {
@@ -1694,18 +1732,23 @@ export class CanvasViewImpl implements CanvasView, Listener {
                     this.resizableShape = null;
 
                     // be sure, that rotation in range [0; 360]
-                    let rotation = getRoundedRotation(shape);
+                    // (skeleton: the group is never rotated — the gesture
+                    // angle was tracked in skeletonGestureRotation and will be
+                    // baked into keypoint coordinates by cvat-core)
+                    let rotation = state.shapeType === 'skeleton' ?
+                        Math.round(skeletonGestureRotation) :
+                        getRoundedRotation(shape);
                     while (rotation < 0) rotation += 360;
                     rotation %= 360;
 
                     if (resized) {
                         if (state.shapeType === 'skeleton') {
-                            // Bbox-only resize: keypoints stayed put, only the
-                            // wrapping rect changed (and possibly the parent
-                            // rotation via the rotation handle). Emit the new
-                            // bbox in canvas-space; element points are passed
-                            // through unchanged so cvat-core knows this edit
-                            // does not touch keypoints.
+                            // Corner/edge resize: keypoints stayed put, only
+                            // the wrapping rect changed. Rotation handle: the
+                            // angle is emitted and baked into keypoints in
+                            // cvat-core; the bbox stays axis-aligned (it only
+                            // auto-expands there if rotated keypoints exceed
+                            // it). Element points are passed through unchanged.
                             const points: number[] = [];
                             state.elements.forEach((element: any) => {
                                 const elementShape = (shape as SVG.G).children()
@@ -4031,6 +4074,12 @@ export class CanvasViewImpl implements CanvasView, Listener {
         if (state.hidden || state.outside || this.isInnerHidden(state.clientID)) {
             skeleton.addClass('cvat_canvas_hidden');
         }
+
+        // NOTE: no rotation transform is applied here on purpose. Skeleton
+        // rotation is always baked into the keypoint coordinates on save
+        // (state.rotation stays 0) and the wrapping rect is an axis-aligned
+        // rectangle by definition — nothing in a skeleton ever carries a
+        // persistent SVG rotation.
 
         (skeleton as any).selectize = (enabled: boolean) => {
             this.selectize(enabled, wrappingRect);

--- a/cvat-core/src/annotations-objects.ts
+++ b/cvat-core/src/annotations-objects.ts
@@ -3715,9 +3715,44 @@ export class SkeletonTrack extends Track {
         const rightPosition = Number.isInteger(rightKeyframe) ? this.shapes[rightKeyframe] : null;
         const leftPosition = Number.isInteger(leftFrame) ? this.shapes[leftFrame] : null;
 
-        const bboxOf = (shape: any): number[] => {
+        // Resolve a keyframe's bbox for interpolation. A degenerate/empty
+        // bbox ([0,0,0,0] or missing) means "not persisted — fall back to the
+        // keypoint extent". It must be resolved to that extent BEFORE
+        // interpolating: interpolating the literal zeros produces a small box
+        // growing out of the image origin that no longer wraps the keypoints
+        // (e.g. a first keyframe left at [0,0,0,0] while a later keyframe got
+        // a real bbox). Mirrors the SkeletonShape constructor / addSkeleton
+        // fallback (keypoint min/max + margin).
+        const SKELETON_TRACK_BBOX_FALLBACK_MARGIN = 20;
+        const resolveBbox = (shape: any, frame: number): number[] => {
             const b = shape && shape.bbox;
-            return Array.isArray(b) && b.length === 4 ? b : [0, 0, 0, 0];
+            const valid = Array.isArray(b) && b.length === 4 &&
+                !(b[0] === 0 && b[1] === 0 && b[2] === 0 && b[3] === 0);
+            if (valid) return b;
+            let xtl = Number.POSITIVE_INFINITY;
+            let ytl = Number.POSITIVE_INFINITY;
+            let xbr = Number.NEGATIVE_INFINITY;
+            let ybr = Number.NEGATIVE_INFINITY;
+            for (const element of this.elements) {
+                const position = element.get(frame);
+                if (position.outside) continue;
+                const pts = position.points as number[];
+                for (let i = 0; i < pts.length; i += 2) {
+                    xtl = Math.min(xtl, pts[i]);
+                    ytl = Math.min(ytl, pts[i + 1]);
+                    xbr = Math.max(xbr, pts[i]);
+                    ybr = Math.max(ybr, pts[i + 1]);
+                }
+            }
+            if (Number.isFinite(xtl)) {
+                return [
+                    xtl - SKELETON_TRACK_BBOX_FALLBACK_MARGIN,
+                    ytl - SKELETON_TRACK_BBOX_FALLBACK_MARGIN,
+                    xbr + SKELETON_TRACK_BBOX_FALLBACK_MARGIN,
+                    ybr + SKELETON_TRACK_BBOX_FALLBACK_MARGIN,
+                ];
+            }
+            return [0, 0, 0, 0];
         };
 
         if (leftPosition && rightPosition) {
@@ -3725,8 +3760,8 @@ export class SkeletonTrack extends Track {
             // how keypoint positions interpolate elsewhere. Rotation is
             // always 0 for skeletons: it bakes into keypoint coordinates on
             // save and is never carried as a state.
-            const leftBbox = bboxOf(leftPosition);
-            const rightBbox = bboxOf(rightPosition);
+            const leftBbox = resolveBbox(leftPosition, leftFrame as number);
+            const rightBbox = resolveBbox(rightPosition, rightKeyframe as number);
             const span = (rightKeyframe as number) - (leftFrame as number);
             const t = span > 0 ? (targetFrame - (leftFrame as number)) / span : 0;
             const interpolatedBbox = [
@@ -3748,6 +3783,7 @@ export class SkeletonTrack extends Track {
 
         const singlePosition = leftPosition || rightPosition;
         if (singlePosition) {
+            const frame = singlePosition === leftPosition ? (leftFrame as number) : (rightKeyframe as number);
             return {
                 rotation: 0,
                 occluded: singlePosition.occluded,
@@ -3755,7 +3791,7 @@ export class SkeletonTrack extends Track {
                 keyframe: targetFrame in this.shapes,
                 outside: singlePosition === rightPosition ? true : singlePosition.outside,
                 points: [],
-                bbox: bboxOf(singlePosition),
+                bbox: resolveBbox(singlePosition, frame),
             };
         }
 

--- a/cvat-core/src/annotations-objects.ts
+++ b/cvat-core/src/annotations-objects.ts
@@ -19,7 +19,7 @@ import logger from './logger';
 import { SerializedShape, SerializedTrack, SerializedTag } from './server-response-types';
 import {
     checkNumberOfPoints, attrsAsAnObject, checkShapeArea, mask2Rle, rle2Mask,
-    findAngleDiff, rotatePoint, validateAttributeValue, cropMask,
+    computeWrappingBox, findAngleDiff, rotatePoint, validateAttributeValue, cropMask,
 } from './object-utils';
 
 const defaultGroupColor = '#E0E0E0';
@@ -32,6 +32,10 @@ function copyShape(state: TrackedShape, data: Partial<TrackedShape> = {}): Track
         occluded: state.occluded,
         outside: state.outside,
         attributes: {},
+        // skeleton parent keyframes carry a per-frame bbox; dropping it here
+        // would wipe the bbox whenever an implicit keyframe is created
+        // (e.g. rotating or editing on an interpolated frame)
+        ...(Array.isArray(state.bbox) && state.bbox.length === 4 ? { bbox: [...state.bbox] } : {}),
         ...data,
     };
 }
@@ -42,6 +46,10 @@ function convertTrackedShape(shape: SerializedTrack['shapes'][0]): TrackedShape 
         occluded: shape.occluded,
         zOrder: shape.z_order,
         points: shape.points,
+        // skeleton parent keyframes persist a per-frame bbox on the server;
+        // without this the stored bbox is lost on every reload and the canvas
+        // falls back to the keypoint-derived rect
+        ...(Array.isArray(shape.bbox) && shape.bbox.length === 4 ? { bbox: [...shape.bbox] } : {}),
         outside: shape.outside,
         rotation: shape.rotation || 0,
         attributes: shape.attributes.reduce((attributeAccumulator, attr) => {
@@ -827,6 +835,7 @@ interface TrackedShape {
     rotation: number;
     zOrder: number;
     points?: number[];
+    bbox?: number[];
     attributes: Record<number, string>;
 }
 
@@ -2005,10 +2014,12 @@ export class SkeletonShape extends Shape {
         super(data, clientID, color, injection);
         this.shapeType = ShapeType.SKELETON;
         this.pinned = false;
-        // Skeleton rotation is now a meaningful first-class field. The wrapping
-        // bbox stays axis-aligned and rotation is carried separately, so
-        // element keypoints are NOT mutated when the user rotates the skeleton.
-        // Base Shape constructor already initialized this.rotation from data.
+        // Skeleton rotation is always baked into the child keypoint
+        // coordinates on save (see saveRotation) and the bbox stays an
+        // axis-aligned rectangle, so the rotation field carries no meaning
+        // for skeletons and is forced to 0 (this also heals any non-zero
+        // value persisted by interim builds).
+        this.rotation = 0;
         this.occluded = false;
         this.points = [];
         // bbox is the annotator-drawn object boundary. Degenerate state
@@ -2216,30 +2227,82 @@ export class SkeletonShape extends Shape {
     }
 
     protected saveRotation(rotation, frame): void {
-        // Skeleton rotation is now stored on the parent as a scalar; the
-        // wrapping bbox stays axis-aligned and child keypoints are NOT mutated.
-        // Visualization rotates via an SVG transform on the canvas instead.
-        const undoRotation = this.rotation;
-        const redoRotation = rotation;
+        // Skeleton rotation bakes into the child keypoint coordinates
+        // immediately: the parent rotation stays 0 and the bbox remains an
+        // axis-aligned rectangle. The pivot is the stored bbox center (or the
+        // keypoint extent center when no usable bbox exists). If rotated
+        // keypoints land outside the current bbox, the bbox auto-expands —
+        // it never rotates and never shrinks.
+        const undoSkeletonPoints = this.elements.map((element) => element.points);
+        const undoBbox = [...this.bbox];
         const undoSource = this.source;
         const redoSource = this.readOnlyFields.includes('source') ? this.source : computeNewSource(this.source);
 
-        this.rotation = redoRotation;
-        this.source = redoSource;
+        const usableBbox = this.bbox.length === 4 &&
+            !(this.bbox[0] === 0 && this.bbox[1] === 0 && this.bbox[2] === 0 && this.bbox[3] === 0);
+        let cx = 0;
+        let cy = 0;
+        if (usableBbox) {
+            cx = (this.bbox[0] + this.bbox[2]) / 2;
+            cy = (this.bbox[1] + this.bbox[3]) / 2;
+        } else {
+            const wrappingBox = computeWrappingBox(undoSkeletonPoints.flat());
+            cx = wrappingBox.x + wrappingBox.width / 2;
+            cy = wrappingBox.y + wrappingBox.height / 2;
+        }
 
+        for (const element of this.elements) {
+            const { points } = element;
+            const rotatedPoints = [];
+            for (let i = 0; i < points.length; i += 2) {
+                const [x, y] = [points[i], points[i + 1]];
+                rotatedPoints.push(...rotatePoint(x, y, rotation, cx, cy));
+            }
+
+            element.points = rotatedPoints;
+        }
+
+        if (usableBbox) {
+            let [xtl, ytl, xbr, ybr] = this.bbox;
+            for (const element of this.elements) {
+                if (element.outside) continue;
+                const pts = element.points;
+                for (let i = 0; i < pts.length; i += 2) {
+                    xtl = Math.min(xtl, pts[i]);
+                    xbr = Math.max(xbr, pts[i]);
+                    ytl = Math.min(ytl, pts[i + 1]);
+                    ybr = Math.max(ybr, pts[i + 1]);
+                }
+            }
+            this.bbox = [xtl, ytl, xbr, ybr];
+        }
+
+        this.source = redoSource;
+        this.updated = Date.now();
+
+        const redoSkeletonPoints = this.elements.map((element) => element.points);
+        const redoBbox = [...this.bbox];
         this.history.do(
             HistoryActions.CHANGED_ROTATION,
             () => {
-                this.rotation = undoRotation;
+                for (let i = 0; i < this.elements.length; i++) {
+                    this.elements[i].points = undoSkeletonPoints[i];
+                    this.elements[i].updated = Date.now();
+                }
+                this.bbox = [...undoBbox];
                 this.source = undoSource;
                 this.updated = Date.now();
             },
             () => {
-                this.rotation = redoRotation;
+                for (let i = 0; i < this.elements.length; i++) {
+                    this.elements[i].points = redoSkeletonPoints[i];
+                    this.elements[i].updated = Date.now();
+                }
+                this.bbox = [...redoBbox];
                 this.source = redoSource;
                 this.updated = Date.now();
             },
-            [this.clientID],
+            [this.clientID, ...this.elements.map((element) => element.clientID)],
             frame,
         );
     }
@@ -3144,26 +3207,100 @@ export class SkeletonTrack extends Track {
     }
 
     protected saveRotation(rotation: number, frame: number): void {
-        // Skeleton track rotation now persists on the parent shape at the given
-        // frame (with implicit keyframe semantics matching savePoints), instead
-        // of rewriting each child keypoint. Visualization is handled by a
-        // canvas SVG transform.
-        const wasKeyframe = frame in this.shapes;
-        const undoShape = wasKeyframe ? this.shapes[frame] : undefined;
+        // Skeleton track rotation bakes into the child keypoint keyframes at
+        // this frame (implicit keyframe semantics): the parent rotation stays
+        // 0 and the per-frame bbox remains an axis-aligned rectangle. The
+        // pivot is the displayed bbox center at this frame (or the keypoint
+        // extent center when no usable bbox exists). If rotated keypoints
+        // land outside the bbox, the bbox at this frame auto-expands — it
+        // never rotates and never shrinks.
+        const undoSkeletonShapes = this.elements.map((element) => element.shapes[frame]);
+        const undoParentShape = frame in this.shapes ? this.shapes[frame] : undefined;
         const undoSource = this.source;
         const redoSource = this.readOnlyFields.includes('source') ? this.source : computeNewSource(this.source);
-        const redoShape = wasKeyframe ?
-            { ...this.shapes[frame], rotation } :
-            { ...copyShape(this.get(frame)), rotation };
 
-        this.shapes[frame] = redoShape;
+        const parentPosition = this.get(frame);
+        const elementsData = this.elements.map((element) => element.get(frame));
+        const skeletonPoints = elementsData.map((data) => data.points);
+
+        const parentBbox = Array.isArray(parentPosition.bbox) && parentPosition.bbox.length === 4 &&
+            !(parentPosition.bbox[0] === 0 && parentPosition.bbox[1] === 0 &&
+                parentPosition.bbox[2] === 0 && parentPosition.bbox[3] === 0) ?
+            [...parentPosition.bbox] :
+            null;
+        let cx = 0;
+        let cy = 0;
+        if (parentBbox) {
+            cx = (parentBbox[0] + parentBbox[2]) / 2;
+            cy = (parentBbox[1] + parentBbox[3]) / 2;
+        } else {
+            const wrappingBox = computeWrappingBox(skeletonPoints.flat());
+            cx = wrappingBox.x + wrappingBox.width / 2;
+            cy = wrappingBox.y + wrappingBox.height / 2;
+        }
+
+        for (let i = 0; i < this.elements.length; i++) {
+            const element = this.elements[i];
+            const { points } = elementsData[i];
+
+            const rotatedPoints = [];
+            for (let j = 0; j < points.length; j += 2) {
+                const [x, y] = [points[j], points[j + 1]];
+                rotatedPoints.push(...rotatePoint(x, y, rotation, cx, cy));
+            }
+
+            if (undoSkeletonShapes[i]) {
+                element.shapes[frame] = {
+                    ...undoSkeletonShapes[i],
+                    points: rotatedPoints,
+                };
+            } else {
+                element.shapes[frame] = {
+                    ...copyShape(elementsData[i]),
+                    points: rotatedPoints,
+                };
+            }
+        }
+
+        if (parentBbox) {
+            let [xtl, ytl, xbr, ybr] = parentBbox;
+            let expanded = false;
+            for (let i = 0; i < this.elements.length; i++) {
+                if (elementsData[i].outside) continue;
+                const pts = this.elements[i].shapes[frame].points;
+                for (let j = 0; j < pts.length; j += 2) {
+                    if (pts[j] < xtl) { xtl = pts[j]; expanded = true; }
+                    if (pts[j] > xbr) { xbr = pts[j]; expanded = true; }
+                    if (pts[j + 1] < ytl) { ytl = pts[j + 1]; expanded = true; }
+                    if (pts[j + 1] > ybr) { ybr = pts[j + 1]; expanded = true; }
+                }
+            }
+            if (expanded) {
+                this.shapes[frame] = frame in this.shapes ?
+                    { ...this.shapes[frame], bbox: [xtl, ytl, xbr, ybr] } :
+                    { ...copyShape(parentPosition), bbox: [xtl, ytl, xbr, ybr] };
+            }
+        }
+
         this.source = redoSource;
+        this.updated = Date.now();
 
+        const redoSkeletonShapes = this.elements.map((element) => element.shapes[frame]);
+        const redoParentShape = frame in this.shapes ? this.shapes[frame] : undefined;
         this.history.do(
             HistoryActions.CHANGED_ROTATION,
             () => {
-                if (undoShape) {
-                    this.shapes[frame] = undoShape;
+                for (let i = 0; i < this.elements.length; i++) {
+                    const element = this.elements[i];
+                    if (undoSkeletonShapes[i]) {
+                        element.shapes[frame] = undoSkeletonShapes[i];
+                    } else {
+                        delete element.shapes[frame];
+                    }
+                    element.updated = Date.now();
+                }
+                if (undoParentShape) {
+                    this.shapes[frame] = undoParentShape;
                 } else {
                     delete this.shapes[frame];
                 }
@@ -3171,11 +3308,20 @@ export class SkeletonTrack extends Track {
                 this.updated = Date.now();
             },
             () => {
-                this.shapes[frame] = redoShape;
+                for (let i = 0; i < this.elements.length; i++) {
+                    const element = this.elements[i];
+                    element.shapes[frame] = redoSkeletonShapes[i];
+                    element.updated = Date.now();
+                }
+                if (redoParentShape) {
+                    this.shapes[frame] = redoParentShape;
+                } else {
+                    delete this.shapes[frame];
+                }
                 this.source = redoSource;
                 this.updated = Date.now();
             },
-            [this.clientID],
+            [this.clientID, ...this.elements.map((element) => element.clientID)],
             frame,
         );
     }
@@ -3532,14 +3678,12 @@ export class SkeletonTrack extends Track {
             const b = shape && shape.bbox;
             return Array.isArray(b) && b.length === 4 ? b : [0, 0, 0, 0];
         };
-        const rotationOf = (shape: any): number => {
-            const r = shape && shape.rotation;
-            return typeof r === 'number' ? r : 0;
-        };
 
         if (leftPosition && rightPosition) {
-            // Linear interpolation of bbox + rotation between two keyframes.
-            // Mirrors how keypoint positions interpolate elsewhere.
+            // Linear interpolation of bbox between two keyframes, mirroring
+            // how keypoint positions interpolate elsewhere. Rotation is
+            // always 0 for skeletons: it bakes into keypoint coordinates on
+            // save and is never carried as a state.
             const leftBbox = bboxOf(leftPosition);
             const rightBbox = bboxOf(rightPosition);
             const span = (rightKeyframe as number) - (leftFrame as number);
@@ -3550,10 +3694,8 @@ export class SkeletonTrack extends Track {
                 leftBbox[2] + (rightBbox[2] - leftBbox[2]) * t,
                 leftBbox[3] + (rightBbox[3] - leftBbox[3]) * t,
             ];
-            const leftRot = rotationOf(leftPosition);
-            const rightRot = rotationOf(rightPosition);
             return {
-                rotation: leftRot + (rightRot - leftRot) * t,
+                rotation: 0,
                 occluded: leftPosition.occluded,
                 outside: leftPosition.outside,
                 zOrder: leftPosition.zOrder,
@@ -3566,7 +3708,7 @@ export class SkeletonTrack extends Track {
         const singlePosition = leftPosition || rightPosition;
         if (singlePosition) {
             return {
-                rotation: rotationOf(singlePosition),
+                rotation: 0,
                 occluded: singlePosition.occluded,
                 zOrder: singlePosition.zOrder,
                 keyframe: targetFrame in this.shapes,

--- a/cvat-core/src/annotations-objects.ts
+++ b/cvat-core/src/annotations-objects.ts
@@ -3343,12 +3343,57 @@ export class SkeletonTrack extends Track {
         const result: SerializedTrack = Track.prototype.toJSON.call(this);
 
         // Parent (skeleton) keyframes carry rotation + bbox per frame.
-        // points are always empty for skeleton parents.
+        // points are always empty for skeleton parents. Each keyframe's bbox
+        // is expanded to contain its own keypoints before export: a stored
+        // bbox can be stale (a shared single-keyframe keypoint moved at a
+        // different frame) or degenerate ([0,0,0,0] placeholder). Keeping each
+        // exported keyframe wrapping its keypoints means interpolation on
+        // re-import stays valid (linear interpolation preserves containment),
+        // matching what the canvas displays via getPosition.
+        const SKELETON_TRACK_BBOX_FALLBACK_MARGIN = 20;
         result.shapes = result.shapes.map((shape) => {
             const storedShape = this.shapes[shape.frame];
-            const bbox = storedShape && Array.isArray((storedShape as any).bbox) ?
+            const stored = storedShape && Array.isArray((storedShape as any).bbox) ?
                 [...(storedShape as any).bbox as number[]] :
-                [0, 0, 0, 0];
+                null;
+            const degenerate = !stored ||
+                (stored[0] === 0 && stored[1] === 0 && stored[2] === 0 && stored[3] === 0);
+
+            let xtl = Number.POSITIVE_INFINITY;
+            let ytl = Number.POSITIVE_INFINITY;
+            let xbr = Number.NEGATIVE_INFINITY;
+            let ybr = Number.NEGATIVE_INFINITY;
+            for (const element of this.elements) {
+                const position = element.get(shape.frame);
+                if (position.outside) continue;
+                const pts = position.points as number[];
+                for (let i = 0; i < pts.length; i += 2) {
+                    xtl = Math.min(xtl, pts[i]);
+                    ytl = Math.min(ytl, pts[i + 1]);
+                    xbr = Math.max(xbr, pts[i]);
+                    ybr = Math.max(ybr, pts[i + 1]);
+                }
+            }
+
+            let bbox: number[];
+            if (!Number.isFinite(xtl)) {
+                bbox = stored || [0, 0, 0, 0];
+            } else if (degenerate) {
+                bbox = [
+                    xtl - SKELETON_TRACK_BBOX_FALLBACK_MARGIN,
+                    ytl - SKELETON_TRACK_BBOX_FALLBACK_MARGIN,
+                    xbr + SKELETON_TRACK_BBOX_FALLBACK_MARGIN,
+                    ybr + SKELETON_TRACK_BBOX_FALLBACK_MARGIN,
+                ];
+            } else {
+                bbox = [
+                    Math.min(stored[0], xtl),
+                    Math.min(stored[1], ytl),
+                    Math.max(stored[2], xbr),
+                    Math.max(stored[3], ybr),
+                ];
+            }
+
             return {
                 ...shape,
                 points: [],
@@ -3755,6 +3800,31 @@ export class SkeletonTrack extends Track {
             return [0, 0, 0, 0];
         };
 
+        // Guarantee the displayed bbox contains every visible keypoint at the
+        // target frame (expand only — the annotator-drawn box is a lower
+        // bound). A stored keyframe bbox can legitimately become stale: a
+        // keypoint with a single keyframe is shared across all frames, so
+        // moving it only soft-snaps the edited frame's bbox and leaves OTHER
+        // keyframes (and everything interpolated from them) no longer
+        // wrapping it. There is no single edit-time hook that can keep every
+        // keyframe consistent, so the invariant is enforced here, at the one
+        // place every frame's bbox is derived.
+        const containKeypoints = (bbox: number[]): number[] => {
+            let [xtl, ytl, xbr, ybr] = bbox;
+            for (const element of this.elements) {
+                const position = element.get(targetFrame);
+                if (position.outside) continue;
+                const pts = position.points as number[];
+                for (let i = 0; i < pts.length; i += 2) {
+                    xtl = Math.min(xtl, pts[i]);
+                    ytl = Math.min(ytl, pts[i + 1]);
+                    xbr = Math.max(xbr, pts[i]);
+                    ybr = Math.max(ybr, pts[i + 1]);
+                }
+            }
+            return [xtl, ytl, xbr, ybr];
+        };
+
         if (leftPosition && rightPosition) {
             // Linear interpolation of bbox between two keyframes, mirroring
             // how keypoint positions interpolate elsewhere. Rotation is
@@ -3777,7 +3847,7 @@ export class SkeletonTrack extends Track {
                 zOrder: leftPosition.zOrder,
                 keyframe: targetFrame in this.shapes,
                 points: [],
-                bbox: interpolatedBbox,
+                bbox: containKeypoints(interpolatedBbox),
             };
         }
 
@@ -3791,7 +3861,7 @@ export class SkeletonTrack extends Track {
                 keyframe: targetFrame in this.shapes,
                 outside: singlePosition === rightPosition ? true : singlePosition.outside,
                 points: [],
-                bbox: resolveBbox(singlePosition, frame),
+                bbox: containKeypoints(resolveBbox(singlePosition, frame)),
             };
         }
 

--- a/cvat-core/src/annotations-objects.ts
+++ b/cvat-core/src/annotations-objects.ts
@@ -3376,7 +3376,7 @@ export class SkeletonTrack extends Track {
             }
 
             let bbox: number[];
-            if (!Number.isFinite(xtl)) {
+            if (![xtl, ytl, xbr, ybr].every(Number.isFinite)) {
                 bbox = stored || [0, 0, 0, 0];
             } else if (degenerate) {
                 bbox = [
@@ -3398,6 +3398,11 @@ export class SkeletonTrack extends Track {
                 ...shape,
                 points: [],
                 bbox,
+                // Skeleton rotation is always baked into child keypoints; the
+                // parent must never carry a non-zero rotation. Force it to 0
+                // here so legacy/interim data that stored a parent rotation
+                // does not round-trip it back to the server on export.
+                rotation: 0,
             };
         });
 
@@ -3789,7 +3794,7 @@ export class SkeletonTrack extends Track {
                     ybr = Math.max(ybr, pts[i + 1]);
                 }
             }
-            if (Number.isFinite(xtl)) {
+            if ([xtl, ytl, xbr, ybr].every(Number.isFinite)) {
                 return [
                     xtl - SKELETON_TRACK_BBOX_FALLBACK_MARGIN,
                     ytl - SKELETON_TRACK_BBOX_FALLBACK_MARGIN,

--- a/cvat-core/src/annotations-objects.ts
+++ b/cvat-core/src/annotations-objects.ts
@@ -2307,43 +2307,6 @@ export class SkeletonShape extends Shape {
         );
     }
 
-    protected saveBbox(bbox: number[], frame: number): void {
-        if (!Array.isArray(bbox) || bbox.length !== 4) {
-            throw new ArgumentError(
-                `Skeleton bbox must be a 4-element array [xtl, ytl, xbr, ybr]; got ${JSON.stringify(bbox)}`,
-            );
-        }
-        const undoBbox = [...this.bbox];
-        const redoBbox = [...bbox];
-        const undoSource = this.source;
-        const redoSource = this.readOnlyFields.includes('source') ? this.source : computeNewSource(this.source);
-
-        this.bbox = redoBbox;
-        this.source = redoSource;
-        // Bump updated immediately. The history redo/undo callbacks also bump
-        // it, but they don't run on the original save path — the canvas diff
-        // logic (drawnState.updated !== state.updated) relies on this so the
-        // wrapping rect gets re-drawn after a soft-snap or programmatic bbox
-        // change.
-        this.updated = Date.now();
-
-        this.history.do(
-            HistoryActions.CHANGED_POINTS,
-            () => {
-                this.bbox = undoBbox;
-                this.source = undoSource;
-                this.updated = Date.now();
-            },
-            () => {
-                this.bbox = redoBbox;
-                this.source = redoSource;
-                this.updated = Date.now();
-            },
-            [this.clientID],
-            frame,
-        );
-    }
-
     public save(frame: number, data: ObjectState): ObjectState {
         if (this.lock && data.lock) {
             return new ObjectState(this.get(frame));
@@ -2356,9 +2319,14 @@ export class SkeletonShape extends Shape {
 
             try {
                 this.history.freeze(true);
-                affectedElements.forEach((element, idx) => {
-                    const annotationContext = this.elements[idx];
-                    annotationContext.save(frame, element);
+                affectedElements.forEach((element) => {
+                    // match by clientID — affectedElements is a filtered
+                    // subset, positional indexing would update wrong elements
+                    const annotationContext = this.elements
+                        .find((el) => el.clientID === element.clientID);
+                    if (annotationContext) {
+                        annotationContext.save(frame, element);
+                    }
                 });
             } finally {
                 this.history.freeze(false);
@@ -2398,10 +2366,6 @@ export class SkeletonShape extends Shape {
         updatedHidden.forEach((el) => { el.updateFlags.hidden = false; });
         updatedLock.forEach((el) => { el.updateFlags.lock = false; });
 
-        if (updatedPoints.length) {
-            updateElements(updatedPoints, HistoryActions.CHANGED_POINTS, 'points');
-        }
-
         if (updatedOccluded.length) {
             updatedOccluded.forEach((el) => { el.updateFlags.occluded = true; });
             updateElements(updatedOccluded, HistoryActions.CHANGED_OCCLUDED, 'occluded');
@@ -2417,45 +2381,93 @@ export class SkeletonShape extends Shape {
             updateElements(updatedLock, HistoryActions.CHANGED_LOCK, 'lock');
         }
 
-        // Persist parent skeleton bbox before delegating to base Shape.save.
-        // Reset the flag so base Shape.save does not see it (we own it here).
+        // Element keypoints and the wrapping bbox always change as ONE user
+        // action (whole-skeleton drag, bbox resize, keypoint move with its
+        // soft-snap). They are applied and recorded as ONE history entry so
+        // that a single undo/redo restores both together. The bbox flag is
+        // consumed here so base Shape.save never sees it.
         let nextBbox: number[] | null = null;
         if ((data.updateFlags as any).bbox) {
             nextBbox = [...(data.bbox as number[])];
             (data.updateFlags as any).bbox = false;
         }
 
-        // Soft-snap: after any keypoint or bbox change, recompute the bbox so
-        // that it always contains every visible/occluded keypoint. Runs
-        // unconditionally because the redux store creates fresh ObjectStates
-        // for parent and children on every fetch, so we can't rely on
-        // `data.elements[i].updateFlags.points` to flag what moved — the
-        // canonical truth is `this.elements[i].points` (internal Shape
-        // instances).
-        const baseBbox = nextBbox ??
-            (this.bbox && this.bbox.length === 4 ? [...this.bbox] : null);
-        if (baseBbox) {
-            let [xtl, ytl, xbr, ybr] = baseBbox;
-            let touched = false;
-            for (const element of this.elements) {
-                if (element.outside) continue;
-                const pts = element.points;
-                for (let i = 0; i < pts.length; i += 2) {
-                    const px = pts[i];
-                    const py = pts[i + 1];
-                    if (px < xtl) { xtl = px; touched = true; }
-                    if (py < ytl) { ytl = py; touched = true; }
-                    if (px > xbr) { xbr = px; touched = true; }
-                    if (py > ybr) { ybr = py; touched = true; }
-                }
-            }
-            if (touched || nextBbox !== null) {
-                nextBbox = [xtl, ytl, xbr, ybr];
-            }
-        }
+        if (updatedPoints.length || nextBbox !== null) {
+            const undoSkeletonPoints = this.elements.map((element) => element.points);
+            const undoBbox = [...this.bbox];
+            const undoSource = this.source;
+            const redoSource = this.readOnlyFields.includes('source') ? this.source : computeNewSource(this.source);
 
-        if (nextBbox !== null) {
-            this.saveBbox(nextBbox, frame);
+            try {
+                this.history.freeze(true);
+                updatedPoints.forEach((element) => {
+                    // match by clientID — updatedPoints is a filtered subset,
+                    // positional indexing would update wrong elements
+                    const annotationContext = this.elements
+                        .find((el) => el.clientID === element.clientID);
+                    if (annotationContext) {
+                        annotationContext.save(frame, element);
+                    }
+                });
+            } finally {
+                this.history.freeze(false);
+            }
+
+            // Soft-snap: the bbox must contain every visible/occluded
+            // keypoint. It only expands here — it never shrinks.
+            const baseBbox = nextBbox ??
+                (this.bbox && this.bbox.length === 4 ? [...this.bbox] : null);
+            if (baseBbox) {
+                let [xtl, ytl, xbr, ybr] = baseBbox;
+                for (const element of this.elements) {
+                    if (element.outside) continue;
+                    const pts = element.points;
+                    for (let i = 0; i < pts.length; i += 2) {
+                        xtl = Math.min(xtl, pts[i]);
+                        xbr = Math.max(xbr, pts[i]);
+                        ytl = Math.min(ytl, pts[i + 1]);
+                        ybr = Math.max(ybr, pts[i + 1]);
+                    }
+                }
+                this.bbox = [xtl, ytl, xbr, ybr];
+            }
+
+            const bboxChanged = this.bbox.length !== undoBbox.length ||
+                this.bbox.some((value, idx) => value !== undoBbox[idx]);
+            if (updatedPoints.length || bboxChanged) {
+                this.source = redoSource;
+                this.updated = Date.now();
+
+                const redoSkeletonPoints = this.elements.map((element) => element.points);
+                const redoBbox = [...this.bbox];
+                this.history.do(
+                    HistoryActions.CHANGED_POINTS,
+                    () => {
+                        for (let i = 0; i < this.elements.length; i++) {
+                            this.elements[i].points = undoSkeletonPoints[i];
+                            this.elements[i].updated = Date.now();
+                        }
+                        this.bbox = [...undoBbox];
+                        this.source = undoSource;
+                        this.updated = Date.now();
+                    },
+                    () => {
+                        for (let i = 0; i < this.elements.length; i++) {
+                            this.elements[i].points = redoSkeletonPoints[i];
+                            this.elements[i].updated = Date.now();
+                        }
+                        this.bbox = [...redoBbox];
+                        this.source = redoSource;
+                        this.updated = Date.now();
+                    },
+                    [this.clientID, ...this.elements.map((element) => element.clientID)],
+                    frame,
+                );
+            } else {
+                // nothing actually changed (e.g. a duplicated/no-op event) —
+                // do not pollute history or change the source
+                this.bbox = undoBbox;
+            }
         }
 
         const result = Shape.prototype.save.call(this, frame, data);
@@ -3326,50 +3338,6 @@ export class SkeletonTrack extends Track {
         );
     }
 
-    protected saveBbox(bbox: number[], frame: number): void {
-        if (!Array.isArray(bbox) || bbox.length !== 4) {
-            throw new ArgumentError(
-                `Skeleton bbox must be a 4-element array [xtl, ytl, xbr, ybr]; got ${JSON.stringify(bbox)}`,
-            );
-        }
-        // Mirror savePoints semantics so editing an interpolated frame implicitly
-        // promotes that frame to a keyframe (matches keypoint editing UX).
-        const wasKeyframe = frame in this.shapes;
-        const undoShape = wasKeyframe ? this.shapes[frame] : undefined;
-        const undoSource = this.source;
-        const redoSource = this.readOnlyFields.includes('source') ? this.source : computeNewSource(this.source);
-        const redoShape = wasKeyframe ?
-            { ...this.shapes[frame], bbox: [...bbox] } :
-            { ...copyShape(this.get(frame)), bbox: [...bbox] };
-
-        this.shapes[frame] = redoShape;
-        this.source = redoSource;
-        // See SkeletonShape.saveBbox — bump updated immediately so the canvas
-        // redraw diff picks up the new bbox without waiting for a separate
-        // user action on the wrapping rect.
-        this.updated = Date.now();
-
-        this.history.do(
-            HistoryActions.CHANGED_POINTS,
-            () => {
-                if (undoShape) {
-                    this.shapes[frame] = undoShape;
-                } else {
-                    delete this.shapes[frame];
-                }
-                this.source = undoSource;
-                this.updated = Date.now();
-            },
-            () => {
-                this.shapes[frame] = redoShape;
-                this.source = redoSource;
-                this.updated = Date.now();
-            },
-            [this.clientID],
-            frame,
-        );
-    }
-
     // Method is used to export data to the server
     public toJSON(): SerializedTrack {
         const result: SerializedTrack = Track.prototype.toJSON.call(this);
@@ -3494,10 +3462,15 @@ export class SkeletonTrack extends Track {
             const errors = [];
             try {
                 this.history.freeze(true);
-                affectedElements.forEach((element, idx) => {
+                affectedElements.forEach((element) => {
                     try {
-                        const annotationContext = this.elements[idx];
-                        annotationContext.save(frame, element);
+                        // match by clientID — affectedElements is a filtered
+                        // subset, positional indexing would update wrong elements
+                        const annotationContext = this.elements
+                            .find((el) => el.clientID === element.clientID);
+                        if (annotationContext) {
+                            annotationContext.save(frame, element);
+                        }
                     } catch (error: any) {
                         errors.push(error);
                     }
@@ -3561,10 +3534,6 @@ export class SkeletonTrack extends Track {
         updatedHidden.forEach((el) => { el.updateFlags.hidden = false; });
         updatedLock.forEach((el) => { el.updateFlags.lock = false; });
 
-        if (updatedPoints.length) {
-            updateElements(updatedPoints, HistoryActions.CHANGED_POINTS);
-        }
-
         if (updatedOccluded.length) {
             updatedOccluded.forEach((el) => { el.updateFlags.occluded = true; });
             updateElements(updatedOccluded, HistoryActions.CHANGED_OCCLUDED);
@@ -3594,73 +3563,145 @@ export class SkeletonTrack extends Track {
             updateElements(updatedLock, HistoryActions.CHANGED_LOCK, 'lock');
         }
 
-        // Persist skeleton bbox at this frame (implicit keyframe semantics)
-        // before delegating to base Track.save.
+        // Element keypoints and the per-frame bbox change as ONE user action
+        // (whole-skeleton drag, bbox resize, keypoint move with soft-snap),
+        // so they are applied and recorded as ONE history entry — a single
+        // undo restores both together. Implicit keyframe semantics: editing
+        // an interpolated frame promotes it to a keyframe, for the elements
+        // and the parent bbox alike. The bbox flag is consumed here so base
+        // Track.save never sees it.
         let nextBbox: number[] | null = null;
         if ((data.updateFlags as any).bbox) {
             nextBbox = [...(data.bbox as number[])];
             (data.updateFlags as any).bbox = false;
         }
 
-        // Soft-snap: keep the per-frame bbox tight around visible/occluded
-        // keypoints after any keypoint or bbox change. Runs unconditionally
-        // (same rationale as SkeletonShape.save): redux store creates fresh
-        // ObjectStates on every fetch, so we cannot rely on
-        // `data.elements[i].updateFlags.points` to flag what moved — the
-        // canonical truth is `this.elements[i].get(frame).points`.
-        //
-        // When the stored shape at this frame has no bbox (or the legacy
-        // [0,0,0,0] fallback), seed the soft-snap from the keypoints + a small
-        // visual margin so the first edit does not collapse the bbox onto the
-        // keypoint corner. Matches SkeletonShape constructor's fallback.
-        const SKELETON_TRACK_BBOX_FALLBACK_MARGIN = 20;
-        const storedShape = this.shapes[frame];
-        const storedBbox = storedShape && Array.isArray((storedShape as any).bbox) &&
-            (storedShape as any).bbox.length === 4 ?
-            [...(storedShape as any).bbox as number[]] :
-            null;
-        const storedIsDegenerate = !storedBbox ||
-            (storedBbox[0] === 0 && storedBbox[1] === 0 &&
-                storedBbox[2] === 0 && storedBbox[3] === 0);
+        if (updatedPoints.length || nextBbox !== null) {
+            const undoSkeletonShapes = this.elements.map((element) => element.shapes[frame]);
+            const undoParentShape = frame in this.shapes ? this.shapes[frame] : undefined;
+            const undoSource = this.source;
+            const redoSource = this.readOnlyFields.includes('source') ? this.source : computeNewSource(this.source);
 
-        const seedBbox = nextBbox ?? (storedBbox && !storedIsDegenerate ? storedBbox : null);
-        if (seedBbox || nextBbox !== null || updatedPoints.length > 0 || storedShape) {
+            // displayed (possibly interpolated) parent position before the edit
+            const parentPosition = this.get(frame);
+
+            const errors = [];
+            try {
+                this.history.freeze(true);
+                updatedPoints.forEach((element) => {
+                    try {
+                        // match by clientID — updatedPoints is a filtered subset,
+                        // positional indexing would update wrong elements
+                        const annotationContext = this.elements
+                            .find((el) => el.clientID === element.clientID);
+                        if (annotationContext) {
+                            annotationContext.save(frame, element);
+                        }
+                    } catch (error: any) {
+                        errors.push(error);
+                    }
+                });
+            } finally {
+                this.history.freeze(false);
+            }
+
+            // Soft-snap: the per-frame bbox must contain every visible/occluded
+            // keypoint; it only expands, it never shrinks. When there is no
+            // usable bbox yet (legacy data), derive one from the keypoint
+            // extent plus a small visual margin (matches SkeletonShape).
+            const SKELETON_TRACK_BBOX_FALLBACK_MARGIN = 20;
+            const displayedBbox = Array.isArray(parentPosition.bbox) && parentPosition.bbox.length === 4 &&
+                !(parentPosition.bbox[0] === 0 && parentPosition.bbox[1] === 0 &&
+                    parentPosition.bbox[2] === 0 && parentPosition.bbox[3] === 0) ?
+                [...parentPosition.bbox] :
+                null;
+            const seedBbox = nextBbox ?? displayedBbox;
             let xtl = seedBbox ? seedBbox[0] : Number.POSITIVE_INFINITY;
             let ytl = seedBbox ? seedBbox[1] : Number.POSITIVE_INFINITY;
             let xbr = seedBbox ? seedBbox[2] : Number.NEGATIVE_INFINITY;
             let ybr = seedBbox ? seedBbox[3] : Number.NEGATIVE_INFINITY;
-            let touched = !seedBbox; // when seeding from keypoints we must add the margin
             for (const element of this.elements) {
                 const elementPosition = element.get(frame);
                 if (elementPosition.outside) continue;
                 const pts = elementPosition.points as number[];
                 for (let i = 0; i < pts.length; i += 2) {
-                    const px = pts[i];
-                    const py = pts[i + 1];
-                    if (px < xtl) { xtl = px; touched = true; }
-                    if (py < ytl) { ytl = py; touched = true; }
-                    if (px > xbr) { xbr = px; touched = true; }
-                    if (py > ybr) { ybr = py; touched = true; }
+                    xtl = Math.min(xtl, pts[i]);
+                    xbr = Math.max(xbr, pts[i]);
+                    ytl = Math.min(ytl, pts[i + 1]);
+                    ybr = Math.max(ybr, pts[i + 1]);
                 }
             }
-            if (touched && Number.isFinite(xtl) && Number.isFinite(ytl) &&
+            let mergedBbox: number[] | null = null;
+            if (Number.isFinite(xtl) && Number.isFinite(ytl) &&
                 Number.isFinite(xbr) && Number.isFinite(ybr)) {
-                if (!seedBbox) {
-                    // No usable prior bbox — emit a freshly-derived one with margin.
-                    nextBbox = [
-                        xtl - SKELETON_TRACK_BBOX_FALLBACK_MARGIN,
-                        ytl - SKELETON_TRACK_BBOX_FALLBACK_MARGIN,
-                        xbr + SKELETON_TRACK_BBOX_FALLBACK_MARGIN,
-                        ybr + SKELETON_TRACK_BBOX_FALLBACK_MARGIN,
-                    ];
-                } else if (touched || nextBbox !== null) {
-                    nextBbox = [xtl, ytl, xbr, ybr];
-                }
+                mergedBbox = seedBbox ? [xtl, ytl, xbr, ybr] : [
+                    xtl - SKELETON_TRACK_BBOX_FALLBACK_MARGIN,
+                    ytl - SKELETON_TRACK_BBOX_FALLBACK_MARGIN,
+                    xbr + SKELETON_TRACK_BBOX_FALLBACK_MARGIN,
+                    ybr + SKELETON_TRACK_BBOX_FALLBACK_MARGIN,
+                ];
             }
-        }
 
-        if (nextBbox !== null) {
-            this.saveBbox(nextBbox, frame);
+            const bboxChanged = mergedBbox !== null &&
+                (displayedBbox === null || mergedBbox.some((value, idx) => value !== displayedBbox[idx]));
+
+            if (updatedPoints.length || bboxChanged) {
+                if (mergedBbox !== null) {
+                    this.shapes[frame] = undoParentShape !== undefined ?
+                        { ...undoParentShape, bbox: mergedBbox } :
+                        { ...copyShape(parentPosition), bbox: mergedBbox };
+                }
+                this.source = redoSource;
+                this.updated = Date.now();
+
+                const redoSkeletonShapes = this.elements.map((element) => element.shapes[frame]);
+                const redoParentShape = frame in this.shapes ? this.shapes[frame] : undefined;
+                this.history.do(
+                    HistoryActions.CHANGED_POINTS,
+                    () => {
+                        for (let i = 0; i < this.elements.length; i++) {
+                            const element = this.elements[i];
+                            if (undoSkeletonShapes[i]) {
+                                element.shapes[frame] = undoSkeletonShapes[i];
+                            } else {
+                                delete element.shapes[frame];
+                            }
+                            element.updated = Date.now();
+                        }
+                        if (undoParentShape) {
+                            this.shapes[frame] = undoParentShape;
+                        } else {
+                            delete this.shapes[frame];
+                        }
+                        this.source = undoSource;
+                        this.updated = Date.now();
+                    },
+                    () => {
+                        for (let i = 0; i < this.elements.length; i++) {
+                            const element = this.elements[i];
+                            if (redoSkeletonShapes[i]) {
+                                element.shapes[frame] = redoSkeletonShapes[i];
+                            } else {
+                                delete element.shapes[frame];
+                            }
+                            element.updated = Date.now();
+                        }
+                        if (redoParentShape) {
+                            this.shapes[frame] = redoParentShape;
+                        } else {
+                            delete this.shapes[frame];
+                        }
+                        this.source = redoSource;
+                        this.updated = Date.now();
+                    },
+                    [this.clientID, ...this.elements.map((element) => element.clientID)],
+                    frame,
+                );
+            }
+
+            if (errors.length) {
+                throw new Error(`Several errors occurred during saving skeleton:\n ${errors.join(';\n')}`);
+            }
         }
 
         const result = Track.prototype.save.call(this, frame, data);

--- a/cvat-core/src/object-state.ts
+++ b/cvat-core/src/object-state.ts
@@ -263,8 +263,8 @@ export default class ObjectState {
                         return [];
                     },
                     set: (points) => {
-                        if (!Array.isArray(points) || points.some((coord) => typeof coord !== 'number')) {
-                            throw new ArgumentError('Points are expected to be an array of numbers.');
+                        if (!Array.isArray(points) || points.some((coord) => !Number.isFinite(coord))) {
+                            throw new ArgumentError('Points are expected to be an array of finite numbers.');
                         }
 
                         if (data.shapeType === ShapeType.SKELETON) {
@@ -314,9 +314,9 @@ export default class ObjectState {
                             );
                         }
                         if (!Array.isArray(bbox) || bbox.length !== 4 ||
-                            bbox.some((coord) => typeof coord !== 'number')) {
+                            bbox.some((coord) => !Number.isFinite(coord))) {
                             throw new ArgumentError(
-                                'bbox must be a 4-element number array [xtl, ytl, xbr, ybr].',
+                                'bbox must be a 4-element array of finite numbers [xtl, ytl, xbr, ybr].',
                             );
                         }
                         data.updateFlags.bbox = true;

--- a/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/canvas-wrapper.tsx
+++ b/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/canvas-wrapper.tsx
@@ -941,9 +941,14 @@ class CanvasWrapperComponent extends React.PureComponent<Props> {
     private onCanvasMultiEdited = (event: any): void => {
         const { onUpdateMultipleAnnotations } = this.props;
         const { edits } = event.detail;
-        const statesToUpdate = edits.map((edit: { state: any; points: number[] }) => {
+        const statesToUpdate = edits.map((edit: { state: any; points: number[]; bbox?: number[] }) => {
             const updatedState = edit.state;
             updatedState.points = edit.points;
+            // Skeletons carry the translated wrapping bbox so it moves with the
+            // keypoints instead of expanding to cover the old + new positions.
+            if (updatedState.shapeType === 'skeleton' && Array.isArray(edit.bbox) && edit.bbox.length === 4) {
+                updatedState.bbox = edit.bbox;
+            }
             return updatedState;
         });
         onUpdateMultipleAnnotations(statesToUpdate);

--- a/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/canvas-wrapper.tsx
+++ b/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/canvas-wrapper.tsx
@@ -1028,35 +1028,27 @@ class CanvasWrapperComponent extends React.PureComponent<Props> {
             updateActiveControl(ActiveControl.CURSOR);
         }
         // Skeleton keypoint edits arrive with the element's ObjectState.
-        // Bundling the parent SkeletonShape into the same save batch lets
-        // SkeletonShape.save run its soft-snap pass (which recomputes the
-        // wrapping bbox from the updated keypoints). Without this, the
-        // child save runs in isolation and the bbox never updates until
-        // the user touches the wrapping rect by hand.
-        //
-        // The redux store holds a separate ObjectState for the parent whose
-        // elements[] are fresh ObjectState instances (not the same object as
-        // the edited element state). SkeletonShape.save inspects the
-        // parent's own elements[*].updateFlags.points to decide which
-        // children moved — so we forward the edited element's points onto
-        // its matching child inside the parent state before dispatching.
-        const statesToUpdate: any[] = [state];
+        // The edit is forwarded onto the matching child inside the PARENT
+        // state and only the parent is dispatched: SkeletonShape/SkeletonTrack
+        // .save apply the child update and the soft-snapped bbox together as
+        // ONE history entry, so a single undo restores keypoints and bbox at
+        // once. Saving the child separately would both duplicate the change
+        // and split the action into several undo steps.
+        let statesToUpdate: any[] = [state];
         if (Number.isInteger(state.parentID) && Array.isArray(annotations)) {
             const parentState = annotations.find(
                 (s: any) => s.clientID === state.parentID,
             );
             if (parentState && parentState.shapeType === 'skeleton' &&
-                !statesToUpdate.includes(parentState)) {
-                if (Array.isArray(points) && points.length > 0 &&
-                    Array.isArray(parentState.elements)) {
-                    const childInParent = parentState.elements.find(
-                        (el: any) => el.clientID === state.clientID,
-                    );
-                    if (childInParent) {
-                        childInParent.points = points;
-                    }
+                Array.isArray(points) && points.length > 0 &&
+                Array.isArray(parentState.elements)) {
+                const childInParent = parentState.elements.find(
+                    (el: any) => el.clientID === state.clientID,
+                );
+                if (childInParent) {
+                    childInParent.points = points;
+                    statesToUpdate = [parentState];
                 }
-                statesToUpdate.push(parentState);
             }
         }
         onUpdateAnnotations(statesToUpdate);


### PR DESCRIPTION
## Summary

Fixes a cascade of regressions in the skeleton-bbox feature (bbox as a first-class field on skeleton shapes/tracks). All fixes were reproduced and verified live in the browser; cvat-core/cvat-canvas type-check and ESLint are clean.

The through-line: the bbox feature touched many shared subsystems (rotation, undo/history, track interpolation, serialization, event handling) and each interaction was only half-implemented. The deepest fix establishes the invariant **"the skeleton bbox always contains its keypoints"** at the single point where every frame's bbox is derived (`getPosition`/`toJSON`), because edit-time hooks alone cannot keep independent bbox keyframes consistent when keypoints are shared across frames.

## Fixes (7 commits)

1. **Rotation render** (`70d6a1f8`) — rotation was saved but never re-applied on skeleton redraw, so it snapped back on mouseup. Redefined semantics: rotation bakes into child keypoint coordinates; the bbox stays axis-aligned (pivot = bbox center). Track `copyShape`/`convertTrackedShape` carry per-frame bbox so it isn't lost on implicit-keyframe creation or reload.
2. **Repeated rotation** (`14c09a2f`) — resize listeners were attached to the wrapping rect but detached from the group, so they stacked across activate/deactivate cycles; one gesture fired N events and corrupted the shape from the 2nd rotation on. Detach symmetrically + idempotent attach.
3. **Atomic undo** (`9d27f66c`) — one skeleton edit was recorded as 2–3 history entries (so undo needed multiple presses and intermediate states showed the bbox detached from keypoints). Keypoints + bbox are now applied/recorded as one history entry; element edits dispatch a single parent save (removing a double-save race).
4. **Degenerate keyframe interpolation** (`4a5a500a`) — a first keyframe left at `[0,0,0,0]` was interpolated literally, producing a small box growing from the image origin. `getPosition` resolves a degenerate keyframe bbox to its keypoint extent before interpolating.
5. **Bbox containment** (`38e14bf9`) — a keypoint shared across frames (single keyframe) could move at one frame and leave other keyframes' bboxes stale, so keypoints poked outside the box. `getPosition` (display) and `toJSON` (export) now always expand the derived bbox to contain the frame's visible keypoints (expand-only; the annotator's box is a lower bound).
6. **Codex-review findings** (`cb77f85b`) — independent review surfaced four further issues, all fixed:
   - Multi-dragging a skeleton with other objects left its bbox behind (bbox now travels in the multi-edit payload and translates instead of bloating).
   - `toJSON` re-exported a non-zero parent rotation from legacy data (forced to 0).
   - A keypoint missing from the SVG template could crash later drag-saves on a point-count mismatch (fallback keeps counts aligned; collection logic unified into helpers).
   - Non-finite coords could yield NaN bboxes (finite checks in derivation/export and `ObjectState` setters).

## Verification

- Browser-tested on a local stack: rotation persists and repeats; one undo restores keypoints+bbox together; interpolated and degenerate-keyframe frames wrap the keypoints; a stale-keyframe case wraps at every frame; multi-drag translates the bbox (area unchanged); save→reload→export shows rotation 0, no NaN, bbox wrapping keypoints.
- `tsc --noEmit` and ESLint clean for all changed files (no new type errors vs baseline).
- Changelog fragment updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
